### PR TITLE
Add parameters for configuring disconnected clusters

### DIFF
--- a/chart/templates/HostedCluster.yaml
+++ b/chart/templates/HostedCluster.yaml
@@ -7,7 +7,7 @@ data:
   id_rsa.pub: {{ .Values.sshKey | b64enc | quote }}
 type: Opaque
 ---
-{{- if hasKey .Values "additionalTrustBundle" }}
+{{- if hasKey .Values.disconnected "additionalTrustBundle" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -15,7 +15,7 @@ metadata:
   namespace: {{ .Values.metadata.name | quote }}
 data:
   ca-bundle.crt: |
-    {{- .Values.additionalTrustBundle |  nindent 4 }}
+    {{- .Values.disconnected.additionalTrustBundle |  nindent 4 }}
 ---
 {{- end }}
 apiVersion: hypershift.openshift.io/v1beta1
@@ -26,6 +26,7 @@ metadata:
   annotations:
     helm.sh/hook-weight: "20"
 spec:
+  olmCatalogPlacement: {{ .Values.disconnected.olmCatalogPlacement | default "management" }}
   release:
     image: {{ .Values.hypershift.clusterImageSet | quote }}
   platform:
@@ -49,11 +50,11 @@ spec:
 {{- if hasKey .Values "fips" }}
   fips: {{ .Values.fips }}
 {{- end }}
-{{- if hasKey .Values "imageContentSources" }}
+{{- if hasKey .Values.disconnected "imageContentSources" }}
   imageContentSources:
-    {{- .Values.imageContentSources | toYaml | nindent 4 }}
+    {{- .Values.disconnected.imageContentSources | toYaml | nindent 4 }}
 {{- end }}
-{{- if hasKey .Values "additionalTrustBundle" }}
+{{- if hasKey .Values.disconnected "additionalTrustBundle" }}
   additionalTrustBundle:
     name: trusted-ca
 {{- end }}

--- a/chart/templates/PostSync.yaml
+++ b/chart/templates/PostSync.yaml
@@ -28,6 +28,35 @@ data:
       node_count=$(oc get node --no-headers | wc -l)
     done
     oc wait --timeout=30m --for=condition=ready node --all
+{{- if eq .Values.disconnected.disableAllDefaultSources "true" }}
+  disable_default_catalog_sources.sh: |
+    set -e
+
+    oc patch operatorhub cluster --type json -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'
+{{- end }}
+{{- if hasKey .Values.disconnected "metallb" }}
+  add_operator_catalog_source.sh: |
+    set -e
+
+    cat << EOF | oc apply -f -
+    apiVersion: operators.coreos.com/v1alpha1
+    kind: CatalogSource
+    metadata:
+      name: {{ .Values.disconnected.metallb.catalogSource | default "redhat-operators" }}
+      namespace: openshift-marketplace
+    spec:
+  {{- if hasKey .Values.disconnected.metallb "startingCSV" }}
+      startingCSV: {{ .Values.disconnected.metallb.startingCSV }}
+  {{- end }}
+  {{- if hasKey .Values.disconnected.metallb "image" }}
+      image: {{ .Values.disconnected.metallb.image }}
+  {{- end}}
+      sourceType: grpc
+      updateStrategy:
+        registryPoll:
+          interval: 10m0s
+    EOF
+{{- end }}
   ingress_setup.sh: |
     set -e
 
@@ -168,6 +197,24 @@ spec:
               mountPath: "/script"
               readOnly: true
       containers:
+{{- if eq .Values.disconnected.disableAllDefaultSources "true" }}
+        - name: disable-default-catalog
+          image: {{ include "ocp_client" . }}
+          command:
+           - bash
+          args:
+           - /script/disable_default_catalog_sources.sh
+          env:
+            - name: KUBECONFIG
+              value: "/secrets/kubeconfig"
+          volumeMounts:
+            - name: kubeconfig
+              mountPath: "/secrets"
+              readOnly: true
+            - name: cluster-setup
+              mountPath: "/script"
+              readOnly: true
+{{- end }}
         - name: configure-ingress
           image: {{ include "ocp_client" . }}
           command:

--- a/install-config-example.yaml
+++ b/install-config-example.yaml
@@ -1,5 +1,15 @@
 apiVersion: v1
 
+# Additional parameters for disconnected clusters
+#additionalTrustBundle: |
+#  ca-bundle.crt: |
+#  < certificate bundle >
+
+#imageContentSources:
+#  - mirrors:
+#    - quay-mirror.example/openshift-release-dev/ocp-release
+#    source: quay.io/openshift-release-dev/ocp-release
+
 # Additional parameters for hypershift-helm
 hypershift:
   osImageVersion: "4.12"

--- a/install-config-example.yaml
+++ b/install-config-example.yaml
@@ -1,15 +1,31 @@
 apiVersion: v1
 
-# Additional parameters for disconnected clusters
-#additionalTrustBundle: |
-#  ca-bundle.crt: |
-#  < certificate bundle >
+# Parameters normally only required for disconnected clusters
+#disconnected:
+#  additionalTrustBundle: |
+#    ca-bundle.crt: |
+#    < certificate bundle >
+#  imageContentSources:
+#    - mirrors:
+#      - quay-mirror.example/openshift-release-dev/ocp-release
+#      source: quay.io/openshift-release-dev/ocp-release
+#  
+  # "management" or "guest". defaults to "management"
+#  olmCatalogPlacement: guest
+  
+  # if set to true, will disable all default catalog sources on hosted cluster.
+  # in combination with setting catalog placement to guest this is a workaround to force the worker node to use the imageContentSources we set.
+  # see https://hypershift-docs.netlify.app/how-to/disconnected/known-issues/#olm-default-catalog-sources-in-imagepullbackoff-state
+#  disableAllDefaultSources: false
+  
+  # Settings for the metallb instance on the HCP worker node
+#  metallb:
+#    startingCSV: metallb-operator.v4.12.0-....
+#    image: mirror.example.com/openshift4/redhat-operator-index:v4.12
+    # name of the catalog source containing metallb
+#    catalogSource: redhat-operators
 
-#imageContentSources:
-#  - mirrors:
-#    - quay-mirror.example/openshift-release-dev/ocp-release
-#    source: quay.io/openshift-release-dev/ocp-release
-
+  
 # Additional parameters for hypershift-helm
 hypershift:
   osImageVersion: "4.12"


### PR DESCRIPTION
I added the necessary parameters for making the helm chart work on a disconnected cluster setup.

Also, i moved any related parameters under a seperate key to make the example file more readable.

parameters added:
olmCatalogPlacement: allows setting the OLM catalog placement parameter on the hostedcluster CR

disableAllDefaultSources: adds a script to disable all default sources on the guest cluster.
documentation found here: https://hypershift-docs.netlify.app/how-to/disconnected/known-issues/#olm-default-catalog-sources-in-imagepullbackoff-state

metallb.startingCSV: defines the operator version in the guest cluster operator subscription
metallb.image: defines the image for the metallb operator subscription on the guest cluster
metallb.catalogSource: defines the catalog source for the metallb operator subscription on the guest cluster